### PR TITLE
[Feature] 11월3일 수정내역 패치

### DIFF
--- a/src/main/java/com/leoh/bloomit/common/dto/ApiResponse.java
+++ b/src/main/java/com/leoh/bloomit/common/dto/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.leoh.bloomit.common.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public class ApiResponse<T> {
+
+    private final int status;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), "Success", data);
+    }
+
+    public static <T> ApiResponse<T> error(int status, String message) {
+        return new ApiResponse<>(status, message, null);
+    }
+
+}

--- a/src/main/java/com/leoh/bloomit/common/dto/ApiResponse.java
+++ b/src/main/java/com/leoh/bloomit/common/dto/ApiResponse.java
@@ -1,9 +1,10 @@
 package com.leoh.bloomit.common.dto;
 
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.http.HttpStatus;
 
-@RequiredArgsConstructor
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
 
     private final int status;

--- a/src/main/java/com/leoh/bloomit/common/exception/ErrorCode.java
+++ b/src/main/java/com/leoh/bloomit/common/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.leoh.bloomit.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ResourceNotFoundException
+    GENRE_NOT_FOUND("Genre not found"),
+    ;
+
+    private final String message;
+
+}

--- a/src/main/java/com/leoh/bloomit/common/exception/ErrorCode.java
+++ b/src/main/java/com/leoh/bloomit/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
 
     // ResourceNotFoundException
     GENRE_NOT_FOUND("Genre not found"),
+    MEMBER_NOT_FOUND("Member not found"),
     ;
 
     private final String message;

--- a/src/main/java/com/leoh/bloomit/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/leoh/bloomit/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.leoh.bloomit.common.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+
+    public ResourceNotFoundException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+    }
+}

--- a/src/main/java/com/leoh/bloomit/domain/book/controller/BookController.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/controller/BookController.java
@@ -1,0 +1,27 @@
+package com.leoh.bloomit.domain.book.controller;
+
+import com.leoh.bloomit.common.dto.ApiResponse;
+import com.leoh.bloomit.domain.book.dto.request.BookSaveRequest;
+import com.leoh.bloomit.domain.book.dto.response.BookResponse;
+import com.leoh.bloomit.domain.book.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/books")
+@RequiredArgsConstructor
+public class BookController {
+
+    private final BookService bookService;
+
+    @PostMapping(value = "")
+    public ResponseEntity<ApiResponse<BookResponse>> createBook(@RequestBody BookSaveRequest bookSaveRequest) {
+        BookResponse response = bookService.createBook(bookSaveRequest);
+        return ResponseEntity.status(200).body(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/leoh/bloomit/domain/book/dto/request/BookSaveRequest.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/dto/request/BookSaveRequest.java
@@ -1,16 +1,13 @@
 package com.leoh.bloomit.domain.book.dto.request;
 
 import com.leoh.bloomit.domain.book.entity.Book;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 public class BookSaveRequest {
 

--- a/src/main/java/com/leoh/bloomit/domain/book/dto/response/BookResponse.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/dto/response/BookResponse.java
@@ -6,8 +6,6 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class BookResponse {
 

--- a/src/main/java/com/leoh/bloomit/domain/book/entity/collection/Books.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/entity/collection/Books.java
@@ -1,0 +1,28 @@
+package com.leoh.bloomit.domain.book.entity.collection;
+
+import com.leoh.bloomit.domain.book.dto.response.BookResponse;
+import com.leoh.bloomit.domain.book.entity.Book;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Books {
+
+    private final List<Book> bookList;
+
+    public static Books of(List<Book> books) {
+        return new Books(books);
+    }
+
+    public List<BookResponse> toBookResponse() {
+        if (bookList.isEmpty()) {
+            return List.of();
+        }
+
+        return bookList.stream()
+                .map(BookResponse::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/com/leoh/bloomit/domain/book/service/BookService.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/service/BookService.java
@@ -3,7 +3,7 @@ package com.leoh.bloomit.domain.book.service;
 import com.leoh.bloomit.domain.book.dto.request.BookSaveRequest;
 import com.leoh.bloomit.domain.book.dto.request.BookSearchRequest;
 import com.leoh.bloomit.domain.book.dto.response.BookResponse;
-import com.leoh.bloomit.domain.book.entity.Book;
+import com.leoh.bloomit.domain.book.entity.collection.Books;
 import com.leoh.bloomit.domain.book.enums.BookSearchType;
 import com.leoh.bloomit.domain.book.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,12 +27,11 @@ public class BookService {
     }
 
     public List<BookResponse> search(BookSearchRequest bookSearchRequest) {
-
         validateSearchRequest(bookSearchRequest);
 
-        List<Book> findBooks = findBooksByBookSearchType(bookSearchRequest);
+        Books findBooks = findBooksByBookSearchType(bookSearchRequest);
 
-        return convertBooksToBookResponses(findBooks);
+        return findBooks.toBookResponse();
     }
 
     private void validateSearchRequest(BookSearchRequest bookSearchRequest) {
@@ -45,32 +44,22 @@ public class BookService {
         }
     }
 
-    private List<BookResponse> convertBooksToBookResponses(List<Book> findBooks) {
-        if (findBooks.isEmpty()) {
-            return List.of();
-        }
-
-        return findBooks.stream()
-                .map(BookResponse::fromEntity)
-                .toList();
-    }
-
-    private List<Book> findBooksByBookSearchType(BookSearchRequest bookSearchRequest) {
+    private Books findBooksByBookSearchType(BookSearchRequest bookSearchRequest) {
         BookSearchType bookSearchType = bookSearchRequest.getBookSearchType();
         String keyword = bookSearchRequest.getKeyword();
 
         if (bookSearchType == BookSearchType.TITLE) {
-            return bookRepository.findByTitleContaining(keyword);
+            return Books.of(bookRepository.findByTitleContaining(keyword));
         }
 
         if (bookSearchType == BookSearchType.ISBN) {
-            return bookRepository.findByIsbn(keyword);
+            return Books.of(bookRepository.findByIsbn(keyword));
         }
 
         if (bookSearchType == BookSearchType.AUTHOR) {
-            return bookRepository.findByAuthorContaining(keyword);
+            return Books.of(bookRepository.findByAuthorContaining(keyword));
         }
 
-        return bookRepository.findByPublisherContaining(keyword);
+        return Books.of(bookRepository.findByPublisherContaining(keyword));
     }
 }

--- a/src/main/java/com/leoh/bloomit/domain/book/service/BookService.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/service/BookService.java
@@ -28,29 +28,37 @@ public class BookService {
 
     public List<BookResponse> search(BookSearchRequest bookSearchRequest) {
 
-        BookSearchType bookSearchType = bookSearchRequest.getBookSearchType();
-        String keyword = bookSearchRequest.getKeyword();
+        validateSearchRequest(bookSearchRequest);
 
-        if (ObjectUtils.isEmpty(bookSearchType)) {
+        List<Book> findBooks = findBooksByBookSearchType(bookSearchRequest);
+
+        return convertBooksToBookResponses(findBooks);
+    }
+
+    private void validateSearchRequest(BookSearchRequest bookSearchRequest) {
+        if (ObjectUtils.isEmpty(bookSearchRequest.getBookSearchType())) {
             throw new IllegalArgumentException("BookSearchType cannot be null or empty");
         }
 
-        if (!StringUtils.hasText(keyword)) {
+        if (!StringUtils.hasText(bookSearchRequest.getKeyword())) {
             throw new IllegalArgumentException("Keyword cannot be null or empty");
         }
+    }
 
-        List<Book> findBooks = findBooksByBookSearchType(bookSearchType, keyword);
-
+    private List<BookResponse> convertBooksToBookResponses(List<Book> findBooks) {
         if (findBooks.isEmpty()) {
-            return List.of();    
+            return List.of();
         }
 
         return findBooks.stream()
                 .map(BookResponse::fromEntity)
                 .toList();
     }
-    
-    private List<Book> findBooksByBookSearchType(BookSearchType bookSearchType, String keyword) {
+
+    private List<Book> findBooksByBookSearchType(BookSearchRequest bookSearchRequest) {
+        BookSearchType bookSearchType = bookSearchRequest.getBookSearchType();
+        String keyword = bookSearchRequest.getKeyword();
+
         if (bookSearchType == BookSearchType.TITLE) {
             return bookRepository.findByTitleContaining(keyword);
         }

--- a/src/main/java/com/leoh/bloomit/domain/book/service/BookService.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/service/BookService.java
@@ -3,6 +3,7 @@ package com.leoh.bloomit.domain.book.service;
 import com.leoh.bloomit.domain.book.dto.request.BookSaveRequest;
 import com.leoh.bloomit.domain.book.dto.request.BookSearchRequest;
 import com.leoh.bloomit.domain.book.dto.response.BookResponse;
+import com.leoh.bloomit.domain.book.entity.Book;
 import com.leoh.bloomit.domain.book.entity.collection.Books;
 import com.leoh.bloomit.domain.book.enums.BookSearchType;
 import com.leoh.bloomit.domain.book.repository.BookRepository;
@@ -22,8 +23,9 @@ public class BookService {
     private final BookRepository bookRepository;
 
     @Transactional
-    public void save(BookSaveRequest request) {
-        bookRepository.save(request.toEntity());
+    public BookResponse createBook(BookSaveRequest request) {
+        Book savedBook = bookRepository.save(request.toEntity());
+        return BookResponse.fromEntity(savedBook);
     }
 
     public List<BookResponse> search(BookSearchRequest bookSearchRequest) {

--- a/src/main/java/com/leoh/bloomit/domain/bookgenre/entity/BookGenre.java
+++ b/src/main/java/com/leoh/bloomit/domain/bookgenre/entity/BookGenre.java
@@ -1,0 +1,27 @@
+package com.leoh.bloomit.domain.bookgenre.entity;
+
+import com.leoh.bloomit.domain.book.entity.Book;
+import com.leoh.bloomit.domain.genre.entity.Genre;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "genre_id")
+    private Genre genre;
+
+}

--- a/src/main/java/com/leoh/bloomit/domain/genre/dto/request/GenreSaveRequest.java
+++ b/src/main/java/com/leoh/bloomit/domain/genre/dto/request/GenreSaveRequest.java
@@ -1,0 +1,16 @@
+package com.leoh.bloomit.domain.genre.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GenreSaveRequest {
+
+    private String name;
+
+}

--- a/src/main/java/com/leoh/bloomit/domain/genre/dto/response/GenreResponse.java
+++ b/src/main/java/com/leoh/bloomit/domain/genre/dto/response/GenreResponse.java
@@ -1,0 +1,22 @@
+package com.leoh.bloomit.domain.genre.dto.response;
+
+import com.leoh.bloomit.domain.genre.entity.Genre;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GenreResponse {
+
+    private Long id;
+    private String name;
+
+    public static GenreResponse from(Genre genre) {
+        return new GenreResponse(genre.getId(), genre.getName());
+    }
+
+}

--- a/src/main/java/com/leoh/bloomit/domain/genre/entity/Genre.java
+++ b/src/main/java/com/leoh/bloomit/domain/genre/entity/Genre.java
@@ -1,12 +1,13 @@
 package com.leoh.bloomit.domain.genre.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.leoh.bloomit.domain.bookgenre.entity.BookGenre;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -19,6 +20,13 @@ public class Genre {
 
     private String name;
 
-    private String country;
+    @OneToMany(mappedBy = "genre")
+    private List<BookGenre> bookGenre = new ArrayList<>();
+
+    public static Genre create(String name) {
+        Genre genre = new Genre();
+        genre.name = name;
+        return genre;
+    }
 
 }

--- a/src/main/java/com/leoh/bloomit/domain/genre/repsository/GenreRepository.java
+++ b/src/main/java/com/leoh/bloomit/domain/genre/repsository/GenreRepository.java
@@ -1,0 +1,7 @@
+package com.leoh.bloomit.domain.genre.repsository;
+
+import com.leoh.bloomit.domain.genre.entity.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenreRepository extends JpaRepository<Genre, Long> {
+}

--- a/src/main/java/com/leoh/bloomit/domain/genre/service/GenreService.java
+++ b/src/main/java/com/leoh/bloomit/domain/genre/service/GenreService.java
@@ -1,0 +1,31 @@
+package com.leoh.bloomit.domain.genre.service;
+
+import com.leoh.bloomit.common.exception.ErrorCode;
+import com.leoh.bloomit.common.exception.ResourceNotFoundException;
+import com.leoh.bloomit.domain.genre.dto.request.GenreSaveRequest;
+import com.leoh.bloomit.domain.genre.dto.response.GenreResponse;
+import com.leoh.bloomit.domain.genre.entity.Genre;
+import com.leoh.bloomit.domain.genre.repsository.GenreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GenreService {
+
+    private final GenreRepository genreRepository;
+
+    @Transactional
+    public void save(GenreSaveRequest request) {
+        Genre genre = Genre.create(request.getName());
+        genreRepository.save(genre);
+    }
+
+    public GenreResponse search(long genreId) {
+        return genreRepository.findById(genreId)
+                .map(GenreResponse::from)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.GENRE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/leoh/bloomit/domain/library/entity/Library.java
+++ b/src/main/java/com/leoh/bloomit/domain/library/entity/Library.java
@@ -21,8 +21,7 @@ public class Library extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "library")
     private Member member;
 
     @OneToMany(mappedBy = "library")

--- a/src/main/java/com/leoh/bloomit/domain/library/service/LibraryService.java
+++ b/src/main/java/com/leoh/bloomit/domain/library/service/LibraryService.java
@@ -33,7 +33,4 @@ public class LibraryService {
         return LibrarySearchResponse.create(memberResponse, bookResponses);
     }
 
-    public void save(Library library) {
-        libraryRepository.save(library);
-    }
 }

--- a/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.leoh.bloomit.domain.member.entity;
 
 import com.leoh.bloomit.auth.dto.SignUpDto;
 import com.leoh.bloomit.common.entity.BaseEntity;
+import com.leoh.bloomit.domain.library.entity.Library;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -41,6 +42,10 @@ public class Member extends BaseEntity implements UserDetails {
     @Builder.Default
     private List<String> roles = new ArrayList<>();
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "library_id")
+    private Library library;
+
     public static Member from(SignUpDto signUpDto) {
         return Member.builder()
                 .name(signUpDto.getName())
@@ -55,6 +60,12 @@ public class Member extends BaseEntity implements UserDetails {
         return this.roles.stream()
                 .map(SimpleGrantedAuthority::new)
                 .toList();
+    }
+
+    public Library createLibrary() {
+        Library createdLibrary = Library.create(this);
+        this.library = createdLibrary;
+        return createdLibrary;
     }
 
     @Override

--- a/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
@@ -5,12 +5,8 @@ import com.leoh.bloomit.common.entity.BaseEntity;
 import com.leoh.bloomit.domain.library.entity.Library;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @Entity
@@ -19,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
-public class Member extends BaseEntity implements UserDetails {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,37 +51,10 @@ public class Member extends BaseEntity implements UserDetails {
                 .build();
     }
 
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return this.roles.stream()
-                .map(SimpleGrantedAuthority::new)
-                .toList();
-    }
-
     public Library createLibrary() {
         Library createdLibrary = Library.create(this);
         this.library = createdLibrary;
         return createdLibrary;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
     }
 
 }

--- a/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
@@ -10,9 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
 @Getter
-@AllArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
 public class Member extends BaseEntity {
@@ -42,20 +42,28 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "library_id")
     private Library library;
 
+    public static Member create(String username, String password, String name, String nickname) {
+        Member member = Member.builder()
+                .name(name)
+                .username(username)
+                .password(password)
+                .nickname(nickname)
+                .build();
+        member.library = Library.create(member);
+
+        return member;
+    }
+
     public static Member from(SignUpDto signUpDto) {
-        return Member.builder()
+        Member member = Member.builder()
                 .name(signUpDto.getName())
                 .username(signUpDto.getUsername())
                 .password(signUpDto.getPassword())
                 .nickname(signUpDto.getNickname())
                 .build();
-    }
+        member.library = Library.create(member);
 
-    // Member 에서 Library를 생성하는 게 과연 객체지향 적인가?
-    public Library createAndSetLibrary() {
-        Library createdLibrary = Library.create(this);
-        this.library = createdLibrary;
-        return createdLibrary;
+        return member;
     }
 
 }

--- a/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/entity/Member.java
@@ -51,7 +51,8 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-    public Library createLibrary() {
+    // Member 에서 Library를 생성하는 게 과연 객체지향 적인가?
+    public Library createAndSetLibrary() {
         Library createdLibrary = Library.create(this);
         this.library = createdLibrary;
         return createdLibrary;

--- a/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
@@ -20,7 +20,7 @@ public class MemberService {
             throw new IllegalStateException("Username already exists");
         }
 
-        member.createLibrary();
+        member.createAndSetLibrary();
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
@@ -1,7 +1,5 @@
 package com.leoh.bloomit.domain.member.service;
 
-import com.leoh.bloomit.domain.library.entity.Library;
-import com.leoh.bloomit.domain.library.service.LibraryService;
 import com.leoh.bloomit.domain.member.entity.Member;
 import com.leoh.bloomit.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final LibraryService libraryService;
 
     @Transactional
     public void save(Member member) {
@@ -23,10 +20,8 @@ public class MemberService {
             throw new IllegalStateException("Username already exists");
         }
 
+        member.createLibrary();
         memberRepository.save(member);
-
-        Library library = Library.create(member);
-        libraryService.save(library);
     }
 
     public Member findByUsername(String username) {

--- a/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
@@ -1,11 +1,13 @@
 package com.leoh.bloomit.domain.member.service;
 
+import com.leoh.bloomit.common.exception.ResourceNotFoundException;
 import com.leoh.bloomit.domain.member.entity.Member;
 import com.leoh.bloomit.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.leoh.bloomit.common.exception.ErrorCode.MEMBER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +27,7 @@ public class MemberService {
 
     public Member findByUsername(String username) {
         return memberRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("Username dose not exist"));
+                .orElseThrow(() -> new ResourceNotFoundException(MEMBER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
@@ -20,7 +20,6 @@ public class MemberService {
             throw new IllegalStateException("Username already exists");
         }
 
-        member.createAndSetLibrary();
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
+++ b/src/main/java/com/leoh/bloomit/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.leoh.bloomit.domain.member.service;
 
 import com.leoh.bloomit.common.exception.ResourceNotFoundException;
+import com.leoh.bloomit.domain.member.dto.response.MemberResponse;
 import com.leoh.bloomit.domain.member.entity.Member;
 import com.leoh.bloomit.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,9 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public Member findByUsername(String username) {
+    public MemberResponse findByUsername(String username) {
         return memberRepository.findByUsername(username)
+                .map(MemberResponse::fromEntity)
                 .orElseThrow(() -> new ResourceNotFoundException(MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/com/leoh/bloomit/security/CustomUserDetails.java
+++ b/src/main/java/com/leoh/bloomit/security/CustomUserDetails.java
@@ -1,0 +1,54 @@
+package com.leoh.bloomit.security;
+
+import com.leoh.bloomit.domain.member.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return member.getRoles().stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/leoh/bloomit/security/CustomUserDetailsService.java
+++ b/src/main/java/com/leoh/bloomit/security/CustomUserDetailsService.java
@@ -3,11 +3,9 @@ package com.leoh.bloomit.security;
 import com.leoh.bloomit.domain.member.entity.Member;
 import com.leoh.bloomit.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,21 +13,13 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
-    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findByUsername(username)
-                .map(this::createUserDetails)
+        Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-    }
 
-    private UserDetails createUserDetails(Member member) {
-        return User.builder()
-                .username(member.getUsername())
-                .password(member.getPassword())
-                .roles(member.getRoles().toArray(new String[0]))
-                .build();
+        return new CustomUserDetails(member);
     }
 
 }

--- a/src/test/java/com/leoh/bloomit/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/auth/service/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package com.leoh.bloomit.auth.service;
 
 import com.leoh.bloomit.auth.dto.SignUpDto;
-import com.leoh.bloomit.domain.member.entity.Member;
+import com.leoh.bloomit.domain.member.dto.response.MemberResponse;
 import com.leoh.bloomit.domain.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,12 +38,10 @@ class AuthServiceTest {
         // when
         authService.signUp(signUpDto);
         // then
-        Member findMember = memberService.findByUsername(username);
+        MemberResponse findMember = memberService.findByUsername(username);
         assertThat(findMember).isNotNull()
                 .extracting("username", "nickname", "name")
                 .containsExactly(username, nickname, name);
-
-        assertThat(bCryptPasswordEncoder.matches(password, findMember.getPassword())).isTrue();
     }
 
 }

--- a/src/test/java/com/leoh/bloomit/domain/book/controller/BookControllerTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/book/controller/BookControllerTest.java
@@ -1,0 +1,68 @@
+package com.leoh.bloomit.domain.book.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leoh.bloomit.domain.book.dto.request.BookSaveRequest;
+import com.leoh.bloomit.domain.book.dto.response.BookResponse;
+import com.leoh.bloomit.domain.book.service.BookService;
+import com.leoh.bloomit.security.WithMockCustomUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+@ActiveProfiles("test")
+@WebMvcTest(BookController.class)
+class BookControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BookService bookService;
+
+    @Test
+    @DisplayName("책을 하나 등록한다.")
+    @WithMockCustomUser
+    void save() throws Exception {
+        // given
+        BookSaveRequest bookSaveRequest = BookSaveRequest
+                .builder()
+                .title("Effective Java")
+                .isbn(UUID.randomUUID().toString())
+                .story("굉장히 재밌는 이야기")
+                .description("조슈아 작가의 걸작")
+                .publisher("인사이트")
+                .publishedDate(LocalDateTime.now())
+                .author("Joshua Bloch")
+                .imageUrl("link")
+                .build();
+
+        BookResponse bookResponse = BookResponse.fromEntity(bookSaveRequest.toEntity());
+
+        when(bookService.createBook(any())).thenReturn(bookResponse);
+        // when
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/books")
+                .content(objectMapper.writeValueAsString(bookSaveRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf())
+        ).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+}

--- a/src/test/java/com/leoh/bloomit/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/book/service/BookServiceTest.java
@@ -27,7 +27,7 @@ class BookServiceTest {
     @DisplayName("BookSearchRequest의 bookSearchType이 null이면 IllegalArgumentException 발생")
     void validateBookSearchTypeOfBookSearchRequest() {
         // given
-        BookSearchRequest bookSearchRequest = createBookSearchRequest(null, "keyword");
+        BookSearchRequest bookSearchRequest = createBookBookSearchRequest(null, "keyword");
         // when
         // then
         assertThatThrownBy(() -> bookService.search(bookSearchRequest))
@@ -39,9 +39,9 @@ class BookServiceTest {
     @DisplayName("BookSearchRequest의 keyword가 null이거나 공백이면 IllegalArgumentException 발생")
     void validateKeywordOfBookSearchRequest() {
         // given
-        BookSearchRequest keywordNull = createBookSearchRequest(BookSearchType.TITLE, null);
-        BookSearchRequest keywordEmpty = createBookSearchRequest(BookSearchType.TITLE, "");
-        BookSearchRequest keywordBlank = createBookSearchRequest(BookSearchType.TITLE, " ");
+        BookSearchRequest keywordNull = createBookBookSearchRequest(BookSearchType.TITLE, null);
+        BookSearchRequest keywordEmpty = createBookBookSearchRequest(BookSearchType.TITLE, "");
+        BookSearchRequest keywordBlank = createBookBookSearchRequest(BookSearchType.TITLE, " ");
         // when
         // then
         assertThatThrownBy(() -> bookService.search(keywordNull))
@@ -61,7 +61,7 @@ class BookServiceTest {
     @DisplayName("책 조회 시 조회 결과가 없으면 빈 리스트 반환를 반환한다.")
     void searchResultIsEmpty() {
         // given
-        BookSearchRequest request = createBookSearchRequest(BookSearchType.TITLE, "keyword");
+        BookSearchRequest request = createBookBookSearchRequest(BookSearchType.TITLE, "keyword");
         // when
         List<BookResponse> result = bookService.search(request);
         // then
@@ -72,11 +72,11 @@ class BookServiceTest {
     @DisplayName("책 이름으로 책 목록을 조회한다.(LIKE)")
     void searchBookByTitle() {
         // given
-        createAndSaveRequest("Effective Java", "Joshua", UUID.randomUUID().toString(), "인사이트");
-        createAndSaveRequest("Java TroubleShooting", "이상민", UUID.randomUUID().toString(), "제이펍");
-        createAndSaveRequest("Toby's Spring", "Toby", UUID.randomUUID().toString(), "에이콘");
+        createAndCreateBookRequest("Effective Java", "Joshua", UUID.randomUUID().toString(), "인사이트");
+        createAndCreateBookRequest("Java TroubleShooting", "이상민", UUID.randomUUID().toString(), "제이펍");
+        createAndCreateBookRequest("Toby's Spring", "Toby", UUID.randomUUID().toString(), "에이콘");
 
-        BookSearchRequest bookSearchRequest = createBookSearchRequest(BookSearchType.TITLE, "Java");
+        BookSearchRequest bookSearchRequest = createBookBookSearchRequest(BookSearchType.TITLE, "Java");
 
         // when
         List<BookResponse> bookResponses = bookService.search(bookSearchRequest);
@@ -99,11 +99,11 @@ class BookServiceTest {
         String targetAuthor2 = "Kim Joshua";
         String wrongAuthor = "author";
 
-        createAndSaveRequest("Effective Java", targetAuthor1, "인사이트");
-        createAndSaveRequest("Effective Java", targetAuthor2, "인사이트");
-        createAndSaveRequest("Effective Java", wrongAuthor, "인사이트");
+        createAndCreateBookRequest("Effective Java", targetAuthor1, "인사이트");
+        createAndCreateBookRequest("Effective Java", targetAuthor2, "인사이트");
+        createAndCreateBookRequest("Effective Java", wrongAuthor, "인사이트");
 
-        BookSearchRequest bookSearchRequest =  createBookSearchRequest(BookSearchType.AUTHOR, "Joshua");
+        BookSearchRequest bookSearchRequest =  createBookBookSearchRequest(BookSearchType.AUTHOR, "Joshua");
 
         // when
         List<BookResponse> bookResponses = bookService.search(bookSearchRequest);
@@ -121,9 +121,9 @@ class BookServiceTest {
         // given
         String isbn = UUID.randomUUID().toString();
 
-        createAndSaveRequest("Effective Java", "Joshua", isbn, "인사이트");
+        createAndCreateBookRequest("Effective Java", "Joshua", isbn, "인사이트");
 
-        BookSearchRequest bookSearchRequest = createBookSearchRequest(BookSearchType.ISBN, isbn);
+        BookSearchRequest bookSearchRequest = createBookBookSearchRequest(BookSearchType.ISBN, isbn);
 
         // when
         List<BookResponse> bookResponses = bookService.search(bookSearchRequest);
@@ -143,11 +143,11 @@ class BookServiceTest {
         // given
         String targetPublisher = "인사이트";
 
-        createAndSaveRequest("request1", "Joshua", "인사이트 아웃");
-        createAndSaveRequest("request2", "Joshua", "wrongPublisher");
-        createAndSaveRequest("request3", "Joshua", "인사이트 인");
+        createAndCreateBookRequest("request1", "Joshua", "인사이트 아웃");
+        createAndCreateBookRequest("request2", "Joshua", "wrongPublisher");
+        createAndCreateBookRequest("request3", "Joshua", "인사이트 인");
 
-        BookSearchRequest bookSearchRequest = createBookSearchRequest(BookSearchType.PUBLISHER, targetPublisher);
+        BookSearchRequest bookSearchRequest = createBookBookSearchRequest(BookSearchType.PUBLISHER, targetPublisher);
 
         // when
         List<BookResponse> bookResponses = bookService.search(bookSearchRequest);
@@ -162,14 +162,14 @@ class BookServiceTest {
                 );
     }
 
-    private BookSearchRequest createBookSearchRequest(BookSearchType bookSearchType, String keyword) {
+    private BookSearchRequest createBookBookSearchRequest(BookSearchType bookSearchType, String keyword) {
         return BookSearchRequest.builder()
                 .bookSearchType(bookSearchType)
                 .keyword(keyword)
                 .build();
     }
 
-    private void createAndSaveRequest(String title, String author, String isbn, String publisher) {
+    private void createAndCreateBookRequest(String title, String author, String isbn, String publisher) {
         BookSaveRequest request = BookSaveRequest.builder()
                 .title(title)
                 .author(author)
@@ -178,10 +178,10 @@ class BookServiceTest {
                 .publishedDate(LocalDateTime.now())
                 .build();
 
-        bookService.save(request);
+        bookService.createBook(request);
     }
 
-    private void createAndSaveRequest(String title, String author, String publisher) {
+    private void createAndCreateBookRequest(String title, String author, String publisher) {
         BookSaveRequest request = BookSaveRequest.builder()
                 .title(title)
                 .author(author)
@@ -190,7 +190,7 @@ class BookServiceTest {
                 .publishedDate(LocalDateTime.now())
                 .build();
 
-        bookService.save(request);
+        bookService.createBook(request);
     }
 
 }

--- a/src/test/java/com/leoh/bloomit/domain/genre/service/GenreServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/genre/service/GenreServiceTest.java
@@ -1,0 +1,45 @@
+package com.leoh.bloomit.domain.genre.service;
+
+import com.leoh.bloomit.common.exception.ResourceNotFoundException;
+import com.leoh.bloomit.domain.genre.dto.request.GenreSaveRequest;
+import com.leoh.bloomit.domain.genre.dto.response.GenreResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.leoh.bloomit.common.exception.ErrorCode.GENRE_NOT_FOUND;
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class GenreServiceTest {
+
+    @Autowired
+    private GenreService genreService;
+
+    @Test
+    @DisplayName("장르를 등록한다.")
+    void save() {
+        // given
+        GenreSaveRequest request = new GenreSaveRequest("로맨스");
+        // when
+        genreService.save(request);
+        GenreResponse genreResponse = genreService.search(1L);
+        // then
+        assertThat(genreResponse.getId()).isEqualTo(1L);
+        assertThat(genreResponse.getName()).isEqualTo("로맨스");
+    }
+
+    @Test
+    @DisplayName("장르를 검색할 때, 해당하는 장르가 없으면 ResourceNotFoundException 발생")
+    void searchFail() {
+        // given
+        // when // then
+        assertThatThrownBy(() -> genreService.search(1L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage(GENRE_NOT_FOUND.getMessage());
+    }
+
+}

--- a/src/test/java/com/leoh/bloomit/domain/library/repository/LibraryRepositoryTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/library/repository/LibraryRepositoryTest.java
@@ -39,13 +39,13 @@ class LibraryRepositoryTest {
     private BookRepository bookRepository;
 
     @Test
-    @DisplayName("특정 회원의 서재를 조회한다2.")
+    @DisplayName("특정 회원의 서재를 조회한다.")
     void findByMember() {
         //given
         Member member = createMember("username", "nickname", "name", "password");
+        Library library = member.createLibrary();
+
         memberRepository.save(member);
-        Library library = Library.create(member);
-        libraryRepository.save(library);
 
         String bookTitle1 = "effective java";
         String bookTitle2 = "함께자라기";

--- a/src/test/java/com/leoh/bloomit/domain/library/repository/LibraryRepositoryTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/library/repository/LibraryRepositoryTest.java
@@ -43,7 +43,7 @@ class LibraryRepositoryTest {
     void findByMember() {
         //given
         Member member = createMember("username", "nickname", "name", "password");
-        Library library = member.createLibrary();
+        Library library = member.createAndSetLibrary();
 
         memberRepository.save(member);
 

--- a/src/test/java/com/leoh/bloomit/domain/library/repository/LibraryRepositoryTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/library/repository/LibraryRepositoryTest.java
@@ -42,11 +42,11 @@ class LibraryRepositoryTest {
     @DisplayName("특정 회원의 서재를 조회한다.")
     void findByMember() {
         //given
-        Member member = createMember("username", "nickname", "name", "password");
-        Library library = member.createAndSetLibrary();
+        Member member = Member.create("username", "password]", "name", "nickname");
 
         memberRepository.save(member);
-
+        em.flush();
+        em.clear();
         String bookTitle1 = "effective java";
         String bookTitle2 = "함께자라기";
         String bookTitle3 = "실용주의 프로그래머";
@@ -57,6 +57,8 @@ class LibraryRepositoryTest {
         Book effectiveJava = createBookAndSave(bookTitle1, author1);
         Book growthTogether = createBookAndSave(bookTitle2, author2);
         Book programmer = createBookAndSave(bookTitle3, author3);
+
+        Library library = libraryRepository.findByMemberId(member.getId());
 
         library.addBooks(List.of(
                 effectiveJava, growthTogether, programmer
@@ -93,15 +95,6 @@ class LibraryRepositoryTest {
         bookRepository.save(book);
 
         return book;
-    }
-
-    private Member createMember(String username, String nickname, String name, String password) {
-        return Member.builder()
-                .username(username)
-                .nickname(nickname)
-                .name(name)
-                .password(password)
-                .build();
     }
 
 }

--- a/src/test/java/com/leoh/bloomit/domain/library/service/LibraryServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/library/service/LibraryServiceTest.java
@@ -32,7 +32,7 @@ class LibraryServiceTest {
     @DisplayName("특정 회원의 서재를 조회한다.")
     void findByMember() {
         //given
-        Member member = createMember("username", "nickname", "name", "password");
+        Member member = Member.create("username", "password", "name", "nickname");
         Library library = Library.create(member);
 
         String bookTitle1 = "effective java";
@@ -64,12 +64,4 @@ class LibraryServiceTest {
                 );
     }
 
-    private Member createMember(String username, String nickname, String name, String password) {
-        return Member.builder()
-                .username(username)
-                .nickname(nickname)
-                .name(name)
-                .password(password)
-                .build();
-    }
 }

--- a/src/test/java/com/leoh/bloomit/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/member/repository/MemberRepositoryTest.java
@@ -41,7 +41,7 @@ class MemberRepositoryTest {
         String name = "name";
         String password = "password";
 
-        Member member = createMember(username, nickname, name, password);
+        Member member = Member.create(username, password, name, nickname);
 
         memberRepository.save(member);
 
@@ -63,7 +63,7 @@ class MemberRepositoryTest {
         String name = "name";
         String password = "password";
 
-        Member member = createMember(username, nickname, name, password);
+        Member member = Member.create(username, password, name, nickname);
         memberRepository.save(member);
         em.flush();
         // when
@@ -83,12 +83,4 @@ class MemberRepositoryTest {
         assertThat(result).isFalse();
     }
 
-    private Member createMember(String username, String nickname, String name, String password) {
-        return Member.builder()
-                .username(username)
-                .nickname(nickname)
-                .name(name)
-                .password(password)
-                .build();
-    }
 }

--- a/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
@@ -30,8 +30,8 @@ class MemberServiceTest {
         String nickname = "nickname";
         String name = "name";
         String password = "password";
-        Member member = createMember(username, nickname, name, password);
-        Member member2 = createMember(username, "nickname2", "name2", "password2");
+        Member member = Member.create(username, password, name, nickname);
+        Member member2 = Member.create(username, "password2", "name2", "nickname2");
         memberService.save(member);
         // when
         // then
@@ -48,7 +48,7 @@ class MemberServiceTest {
         String nickname = "nickname";
         String name = "name";
         String password = "password";
-        Member member = createMember(username, nickname, name, password);
+        Member member = Member.create(username, password, name, nickname);
 
         // when
         memberService.save(member);
@@ -66,12 +66,4 @@ class MemberServiceTest {
 
     }
 
-    private Member createMember(String username, String nickname, String name, String password) {
-        return Member.builder()
-                .username(username)
-                .nickname(nickname)
-                .name(name)
-                .password(password)
-                .build();
-    }
 }

--- a/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
@@ -54,7 +54,7 @@ class MemberServiceTest {
 
         // when
         memberService.save(member);
-        Member findMember = memberService.findByUsername(username);
+        MemberResponse findMember = memberService.findByUsername(username);
         LibrarySearchResponse librarySearchResponse = libraryService.findByMemberId(findMember.getId());
         // then
         assertThat(findMember).extracting("username", "nickname", "name")
@@ -90,7 +90,7 @@ class MemberServiceTest {
         Member member = Member.create(username, password, name, nickname);
         memberService.save(member);
         // when
-        Member findMember = memberService.findByUsername(username);
+        MemberResponse findMember = memberService.findByUsername(username);
         // then
         assertThat(findMember)
                 .extracting("username", "nickname", "name")

--- a/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,7 @@
 package com.leoh.bloomit.domain.member.service;
 
+import com.leoh.bloomit.common.exception.ErrorCode;
+import com.leoh.bloomit.common.exception.ResourceNotFoundException;
 import com.leoh.bloomit.domain.library.dto.response.LibrarySearchResponse;
 import com.leoh.bloomit.domain.library.service.LibraryService;
 import com.leoh.bloomit.domain.member.dto.response.MemberResponse;
@@ -64,6 +66,35 @@ class MemberServiceTest {
                         .returns("nickname", MemberResponse::getNickname)
                         .returns("name", MemberResponse::getName);
 
+    }
+
+    @Test
+    @DisplayName("유저명으로 회원 조회 시, 해당 회원이 없으면 ResourceNotFoundException 발생")
+    void findByUsernameNotFoundException() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> memberService.findByUsername("username"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("유저명으로 회원 조회")
+    void findByUsername() {
+        // given
+        String username = "username";
+        String nickname = "nickname";
+        String name = "name";
+        String password = "password";
+        Member member = Member.create(username, password, name, nickname);
+        memberService.save(member);
+        // when
+        Member findMember = memberService.findByUsername(username);
+        // then
+        assertThat(findMember)
+                .extracting("username", "nickname", "name")
+                .containsExactly(username, nickname, name);
     }
 
 }

--- a/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/leoh/bloomit/domain/member/service/MemberServiceTest.java
@@ -6,6 +6,7 @@ import com.leoh.bloomit.domain.library.dto.response.LibrarySearchResponse;
 import com.leoh.bloomit.domain.library.service.LibraryService;
 import com.leoh.bloomit.domain.member.dto.response.MemberResponse;
 import com.leoh.bloomit.domain.member.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,16 +25,22 @@ class MemberServiceTest {
     @Autowired
     private LibraryService libraryService;
 
+    private Member member;
+    private static final String USERNAME = "username";
+    private static final String NICKNAME = "nickname";
+    private static final String NAME = "name";
+    private static final String PASSWORD = "password";
+
+    @BeforeEach
+    void setUp() {
+        member = Member.create(USERNAME, PASSWORD, NAME, NICKNAME);
+    }
+
     @DisplayName("save 호출 시 username이 동일한 Member가 존재하면 IllegalStateException이 발생한다.")
     @Test
     void saveUsernameDuplicatedException() {
         // given
-        String username = "username";
-        String nickname = "nickname";
-        String name = "name";
-        String password = "password";
-        Member member = Member.create(username, password, name, nickname);
-        Member member2 = Member.create(username, "password2", "name2", "nickname2");
+        Member member2 = Member.create(USERNAME, "password2", "name2", "nickname2");
         memberService.save(member);
         // when
         // then
@@ -46,25 +53,19 @@ class MemberServiceTest {
     @Test
     void saveSuccess() {
         // given
-        String username = "username";
-        String nickname = "nickname";
-        String name = "name";
-        String password = "password";
-        Member member = Member.create(username, password, name, nickname);
-
         // when
         memberService.save(member);
-        MemberResponse findMember = memberService.findByUsername(username);
+        MemberResponse findMember = memberService.findByUsername(USERNAME);
         LibrarySearchResponse librarySearchResponse = libraryService.findByMemberId(findMember.getId());
         // then
         assertThat(findMember).extracting("username", "nickname", "name")
-                .containsExactly(username, nickname, name);
+                .containsExactly(USERNAME, NICKNAME, NAME);
 
         assertThat(librarySearchResponse).isNotNull()
                         .extracting(LibrarySearchResponse::getMember)
-                        .returns("username", MemberResponse::getUsername)
-                        .returns("nickname", MemberResponse::getNickname)
-                        .returns("name", MemberResponse::getName);
+                        .returns(USERNAME, MemberResponse::getUsername)
+                        .returns(NICKNAME, MemberResponse::getNickname)
+                        .returns(NAME, MemberResponse::getName);
 
     }
 
@@ -74,7 +75,7 @@ class MemberServiceTest {
         // given
         // when
         // then
-        assertThatThrownBy(() -> memberService.findByUsername("username"))
+        assertThatThrownBy(() -> memberService.findByUsername(USERNAME))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage(ErrorCode.MEMBER_NOT_FOUND.getMessage());
     }
@@ -83,18 +84,13 @@ class MemberServiceTest {
     @DisplayName("유저명으로 회원 조회")
     void findByUsername() {
         // given
-        String username = "username";
-        String nickname = "nickname";
-        String name = "name";
-        String password = "password";
-        Member member = Member.create(username, password, name, nickname);
         memberService.save(member);
         // when
-        MemberResponse findMember = memberService.findByUsername(username);
+        MemberResponse findMember = memberService.findByUsername(USERNAME);
         // then
         assertThat(findMember)
                 .extracting("username", "nickname", "name")
-                .containsExactly(username, nickname, name);
+                .containsExactly(USERNAME, NICKNAME, NAME);
     }
 
 }

--- a/src/test/java/com/leoh/bloomit/security/WIthMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/leoh/bloomit/security/WIthMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,23 @@
+package com.leoh.bloomit.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+
+public class WIthMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+        final UsernamePasswordAuthenticationToken authenticationToken
+                = new UsernamePasswordAuthenticationToken(annotation.userName(), null,
+                List.of(new SimpleGrantedAuthority(annotation.role())));
+        securityContext.setAuthentication(authenticationToken);
+        return securityContext;
+    }
+}

--- a/src/test/java/com/leoh/bloomit/security/WithMockCustomUser.java
+++ b/src/test/java/com/leoh/bloomit/security/WithMockCustomUser.java
@@ -1,0 +1,13 @@
+package com.leoh.bloomit.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WIthMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String userName() default "user";
+    String role() default "USER";
+}

--- a/src/test/java/com/leoh/bloomit/security/WithMockCustomUser.java
+++ b/src/test/java/com/leoh/bloomit/security/WithMockCustomUser.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
-@WithSecurityContext(factory = WIthMockCustomUserSecurityContextFactory.class)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
 public @interface WithMockCustomUser {
     String userName() default "user";
     String role() default "USER";

--- a/src/test/java/com/leoh/bloomit/security/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/leoh/bloomit/security/WithMockCustomUserSecurityContextFactory.java
@@ -8,7 +8,7 @@ import org.springframework.security.test.context.support.WithSecurityContextFact
 
 import java.util.List;
 
-public class WIthMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
 
     @Override
     public SecurityContext createSecurityContext(WithMockCustomUser annotation) {


### PR DESCRIPTION
## 📄 변경 사항 개요 (Summary)
1.  List<Book>에 대한 일급컬렉션 Books 생성
2. Book을 하나 저장하는 BookController와 그 테스트 코드 작성
3. Member -> Library 영속성 전이 추가
4. WithMockCustomUserSecurityContextFactory 추가

## ✅ 변경 이유 (Reason for Change)
1. List<Book>을 List<BookResponse>로 변환하는 로직이 서비스 레이어에 존재했는데, 이를 Books 일급 컬렉션의 책임이라고 판단하여 생성3. Member가 생성되면 무조건 하나의 Library가 생성되어야 한다. 그리고 Member가 제거되면 Library도 그에 따라 제거되어야 한다. 따라서 Member -> Library의 영속성 전이를 추가하였다.
4. Controller 테스트 시 JWT 인증, 인가를 피하기 위해 WithMockCustomUserSecurityContextFactory 생성

## 🧪 테스트 내용 (Testing Details)
- Member 생성 시 Library가 생성되는 테스트 추가
- LIst<Book>를 사용하던 로직들에 대해 Books로 변경되었는 지 테스트
- BookControllerTest를 통해 WithMockCustomUserSecurityContextFactory 사용 테스트

## 🤔 리뷰 포인트 (Review Points)
- List<Book> -> Books로 일급컬렉션화 한 것이 좋은 시도가 맞는 지 궁금합니다.
- 컨트롤러 테스트 시 WithMockCustomUserSecurityContextFactory를 사용한 점에 대한 피드백이 필요합니다. 다른 좋은 방법이 있으면 공유바랍니다.
- Member와 Library의 영속성이 잘 전이되었는 지 궁금합니다.
- Member를 생성할 때, Library를 같이 생성 및 영속하고 Member 클래스에 createAndSetLibrary 메서드를 구현하였습니다. Member를 생성하는 다른 개발자의 경우 createAndSetLibrary()의 사용을 인지하지 못할 것 같은데, 어떻게 하면 Member가 생성될 때 Library도 하나 생성하는 로직이 우아하게 될 지 궁금합니다. 객체지향적으로요.

## 🚀 추가 설명 (Additional Context)
- 이런식으로 여러 컨텍스트의 코드가 같이 PR을 하게 되는데 그러다 보니 PR을 작성하기가 복잡하고 중구난방이라 어렵습니다. 어떻게 하면 좀 더 좋은 PR이 될 수 있을까요?
