### PR TITLE
feat: 책 검색 컨트롤러 구현

### DIFF
--- a/src/main/java/com/leoh/bloomit/domain/book/controller/BookController.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/controller/BookController.java
@@ -2,14 +2,14 @@ package com.leoh.bloomit.domain.book.controller;
 
 import com.leoh.bloomit.common.dto.ApiResponse;
 import com.leoh.bloomit.domain.book.dto.request.BookSaveRequest;
+import com.leoh.bloomit.domain.book.dto.request.BookSearchRequest;
 import com.leoh.bloomit.domain.book.dto.response.BookResponse;
 import com.leoh.bloomit.domain.book.service.BookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/books")
@@ -21,6 +21,12 @@ public class BookController {
     @PostMapping(value = "")
     public ResponseEntity<ApiResponse<BookResponse>> createBook(@RequestBody BookSaveRequest bookSaveRequest) {
         BookResponse response = bookService.createBook(bookSaveRequest);
+        return ResponseEntity.status(200).body(ApiResponse.success(response));
+    }
+
+    @GetMapping(value = "")
+    public ResponseEntity<ApiResponse<List<BookResponse>>> searchBook(BookSearchRequest bookSearchRequest) {
+        List<BookResponse> response = bookService.search(bookSearchRequest);
         return ResponseEntity.status(200).body(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/leoh/bloomit/domain/book/dto/request/BookSearchRequest.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/dto/request/BookSearchRequest.java
@@ -6,7 +6,8 @@ import lombok.*;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class BookSearchRequest {
 
     private BookSearchType bookSearchType;

--- a/src/main/java/com/leoh/bloomit/domain/book/dto/response/BookResponse.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/dto/response/BookResponse.java
@@ -6,6 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class BookResponse {
 

--- a/src/main/java/com/leoh/bloomit/domain/book/enums/BookSearchType.java
+++ b/src/main/java/com/leoh/bloomit/domain/book/enums/BookSearchType.java
@@ -1,8 +1,28 @@
 package com.leoh.bloomit.domain.book.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+
+@Slf4j
 public enum BookSearchType {
     TITLE,
     ISBN,
     AUTHOR,
-    PUBLISHER
+    PUBLISHER,
+    ;
+
+    @JsonCreator
+    public static BookSearchType from(String sub) {
+        if (!StringUtils.hasText(sub)) {
+            throw new IllegalArgumentException("Invalid BookSearchType");
+        }
+
+        return Arrays.stream(BookSearchType.values())
+                .filter(bookSearchType -> bookSearchType.name().equalsIgnoreCase(sub))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid BookSearchType"));
+    }
 }

--- a/src/test/java/com/leoh/bloomit/security/TestSecurityConfig.java
+++ b/src/test/java/com/leoh/bloomit/security/TestSecurityConfig.java
@@ -1,0 +1,32 @@
+package com.leoh.bloomit.security;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.formLogin(AbstractHttpConfigurer::disable);
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+        http.headers(header -> header.frameOptions(Customizer.withDefaults()).disable());
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/", "/auth/**", "/h2-console/**").permitAll()
+                .anyRequest().authenticated()
+        );
+
+        return http.build();
+    }
+
+}


### PR DESCRIPTION
## 📄 변경 사항 개요 (Summary)
- 책 조회 컨트롤러 구현

## 🛠 변경된 파일 (Changed Files)
- BookController: 책 조회 API 추가
- BookControllerTest: 책 조회 API 테스트 코드 추가
- BookSearchType: Request DTO에서 문자열을 Enum으로 매핑하기 위해 @JsonCreator용 메서드 `from()`추가
